### PR TITLE
Add system tests for MonsterTypeController and CharacterClassController

### DIFF
--- a/src/test/java/com/jefflife/mudmk2/gamedata/adapter/in/CharacterClassControllerSystemTest.java
+++ b/src/test/java/com/jefflife/mudmk2/gamedata/adapter/in/CharacterClassControllerSystemTest.java
@@ -1,0 +1,370 @@
+package com.jefflife.mudmk2.gamedata.adapter.in;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jefflife.mudmk2.gamedata.application.service.model.request.CreateCharacterClassRequest;
+import com.jefflife.mudmk2.gamedata.application.service.model.request.UpdateCharacterClassRequest;
+import com.jefflife.mudmk2.gamedata.application.service.model.response.CharacterClassResponse;
+import com.jefflife.mudmk2.gamedata.application.service.model.PlayerStatModel;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@WithMockUser(username = "test@example.com", roles = "ADMIN") // Assuming ADMIN role is needed for CharacterClass modification
+public class CharacterClassControllerSystemTest {
+
+    private static final String BASE_URL = "/api/character-classes";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void createCharacterClass_shouldCreateCharacterClassAndReturnCreatedResponse() throws Exception {
+        // Given
+        String className = "Test Class";
+        String classCode = "TST_CLS";
+        String description = "A test class.";
+        // Define expected stat bonus for assertion
+        PlayerStatModel expectedStatBonus = new PlayerStatModel(5, 5, 5, 5, 5, 5); // STR, DEX, CON, INT, POW, CHA
+
+        CreateCharacterClassRequest createRequest = CreateCharacterClassRequest.builder()
+                .name(className)
+                .code(classCode)
+                .description(description)
+                .baseHp(100)
+                .baseMp(50)
+                .baseStr(expectedStatBonus.getStr())
+                .baseDex(expectedStatBonus.getDex())
+                .baseCon(expectedStatBonus.getCon())
+                .baseIntelligence(expectedStatBonus.getIntelligence())
+                .basePow(expectedStatBonus.getPow())
+                .baseCha(expectedStatBonus.getCha())
+                .build();
+        String requestJson = objectMapper.writeValueAsString(createRequest);
+
+        // When
+        MvcResult result = mockMvc.perform(post(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        // Then
+        String responseJson = result.getResponse().getContentAsString();
+        CharacterClassResponse response = objectMapper.readValue(responseJson, CharacterClassResponse.class);
+
+        assertThat(response.getId()).isNotNull();
+        assertCharacterClassEquals(response, className, classCode, description, expectedStatBonus);
+
+        // Verify Location header
+        String locationHeader = result.getResponse().getHeader("Location");
+        assertThat(locationHeader).isEqualTo(BASE_URL + "/" + response.getId());
+    }
+
+    @Test
+    void getAllCharacterClasses_shouldReturnAllCharacterClasses() throws Exception {
+        // Given
+        CharacterClassResponse createdClass1 = createTestCharacterClass("Test Class 1", "TST1");
+        CharacterClassResponse createdClass2 = createTestCharacterClass("Test Class 2", "TST2");
+
+        // When
+        List<CharacterClassResponse> classes = getAllCharacterClasses();
+
+        // Then
+        assertThat(classes).isNotNull();
+        assertThat(classes.size()).isGreaterThanOrEqualTo(2);
+
+        assertCharacterClassInList(classes, createdClass1);
+        assertCharacterClassInList(classes, createdClass2);
+    }
+
+    @Test
+    void getCharacterClassById_shouldReturnCharacterClass() throws Exception {
+        // Given
+        CharacterClassResponse createdClass = createTestCharacterClass("Test Class For GetById", "TST_GID");
+
+        // When
+        CharacterClassResponse retrievedClass = getCharacterClassById(createdClass.getId());
+
+        // Then
+        assertThat(retrievedClass.getId()).isEqualTo(createdClass.getId());
+        assertCharacterClassEquals(retrievedClass, "Test Class For GetById", "TST_GID", createdClass.getDescription(), createdClass.getStatBonus());
+    }
+
+    @Test
+    void getCharacterClassByCode_shouldReturnCharacterClass() throws Exception {
+        // Given
+        String classCode = "TST_GCD";
+        CharacterClassResponse createdClass = createTestCharacterClass("Test Class For GetByCode", classCode);
+
+        // When
+        MvcResult result = mockMvc.perform(get(BASE_URL + "/code/" + classCode)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        CharacterClassResponse retrievedClass = objectMapper.readValue(result.getResponse().getContentAsString(), CharacterClassResponse.class);
+
+        // Then
+        assertThat(retrievedClass.getId()).isEqualTo(createdClass.getId());
+        assertCharacterClassEquals(retrievedClass, "Test Class For GetByCode", classCode, createdClass.getDescription(), createdClass.getStatBonus());
+    }
+
+
+    @Test
+    void updateCharacterClass_shouldUpdateAndReturnUpdatedResponse() throws Exception {
+        // Given
+        CharacterClassResponse createdClass = createTestCharacterClass("Original Class Name", "ORG_CLS");
+
+        // When
+        String updatedClassName = "Updated Class Name";
+        String updatedDescription = "Updated description.";
+        PlayerStatModel expectedUpdatedStatBonus = new PlayerStatModel(6, 6, 6, 6, 6, 6); // STR, DEX, CON, INT, POW, CHA
+
+        UpdateCharacterClassRequest updateRequest = UpdateCharacterClassRequest.builder()
+                .name(updatedClassName)
+                .description(updatedDescription)
+                // Assuming code is not updatable via this request, so not setting it.
+                // If code were updatable, it would be: .code("NEW_CODE")
+                .baseHp(110)
+                .baseMp(60)
+                .baseStr(expectedUpdatedStatBonus.getStr())
+                .baseDex(expectedUpdatedStatBonus.getDex())
+                .baseCon(expectedUpdatedStatBonus.getCon())
+                .baseIntelligence(expectedUpdatedStatBonus.getIntelligence())
+                .basePow(expectedUpdatedStatBonus.getPow())
+                .baseCha(expectedUpdatedStatBonus.getCha())
+                .build();
+        CharacterClassResponse updatedClass = updateCharacterClass(createdClass.getId(), updateRequest);
+
+        // Then
+        assertThat(updatedClass.getId()).isEqualTo(createdClass.getId());
+        // Code should not be updatable, so it should remain the original one.
+        assertCharacterClassEquals(updatedClass, updatedClassName, "ORG_CLS", updatedDescription, expectedUpdatedStatBonus);
+
+        // Verify that the class was actually updated in the database
+        CharacterClassResponse retrievedClass = getCharacterClassById(createdClass.getId());
+        assertCharacterClassEquals(retrievedClass, updatedClassName, "ORG_CLS", updatedDescription, expectedUpdatedStatBonus);
+    }
+
+    @Test
+    void deleteCharacterClass_shouldDeleteAndReturnNoContent() throws Exception {
+        // Given
+        CharacterClassResponse createdClass = createTestCharacterClass("Test Class for Delete", "TST_DEL");
+
+        // When
+        deleteCharacterClass(createdClass.getId());
+
+        // Then
+        // Verify that the class was actually deleted from the database
+        mockMvc.perform(get(BASE_URL + "/" + createdClass.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound()); // Assuming a 404 for a deleted resource
+    }
+
+    @Test
+    void initializeDefaultCharacterClasses_shouldReturnOk() throws Exception {
+        // When & Then
+        mockMvc.perform(post(BASE_URL + "/initialize")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        // Optional: Verify side effects, e.g., check if default classes are present
+        // For now, just checking the 200 OK is sufficient as per requirements.
+        // List<CharacterClassResponse> classes = getAllCharacterClasses();
+        // assertThat(classes). ... check for default classes
+    }
+
+    @Test
+    void getCharacterClassById_whenNotFound_shouldReturnNotFound() throws Exception {
+        // Given
+        long nonExistentId = -999L;
+
+        // When & Then
+        mockMvc.perform(get(BASE_URL + "/" + nonExistentId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getCharacterClassByCode_whenNotFound_shouldReturnNotFound() throws Exception {
+        // Given
+        String nonExistentCode = "NON_EXISTENT_CODE";
+
+        // When & Then
+        mockMvc.perform(get(BASE_URL + "/code/" + nonExistentCode)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void updateCharacterClass_whenNotFound_shouldReturnNotFound() throws Exception {
+        // Given
+        long nonExistentId = -999L;
+        UpdateCharacterClassRequest updateRequest = UpdateCharacterClassRequest.builder()
+                .name("Non Existent")
+                .description("Desc")
+                .baseHp(10)
+                .baseMp(10)
+                .baseStr(1).baseDex(1).baseCon(1).baseIntelligence(1).basePow(1).baseCha(1)
+                .build();
+        String requestJson = objectMapper.writeValueAsString(updateRequest);
+
+        // When & Then
+        mockMvc.perform(put(BASE_URL + "/" + nonExistentId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void deleteCharacterClass_whenNotFound_shouldReturnNotFound() throws Exception {
+        // Given
+        long nonExistentId = -999L;
+
+        // When & Then
+        mockMvc.perform(delete(BASE_URL + "/" + nonExistentId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void createCharacterClass_withInvalidInput_shouldReturnBadRequest() throws Exception {
+        // Given
+        // Invalid request: name is blank, which violates @NotBlank. Code is also blank.
+        CreateCharacterClassRequest createRequest = CreateCharacterClassRequest.builder()
+                .name("") // Invalid: blank name
+                .code("") // Invalid: blank code
+                .description("Desc")
+                .baseHp(10)
+                .baseMp(10)
+                .baseStr(1).baseDex(1).baseCon(1).baseIntelligence(1).basePow(1).baseCha(1)
+                .build();
+        String requestJson = objectMapper.writeValueAsString(createRequest);
+
+        // When & Then
+        mockMvc.perform(post(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isBadRequest());
+    }
+
+
+    private CharacterClassResponse createTestCharacterClass(String name, String code) throws Exception {
+        String description = "Default description for " + name;
+        PlayerStatModel statBonus = new PlayerStatModel(1, 1, 1, 1, 1, 1); // Default stats, ensuring all fields are present
+        CreateCharacterClassRequest createRequest = new CreateCharacterClassRequest(name, code, description, statBonus, Collections.emptyList());
+        // Corrected the PlayerStatModel to match the constructor (str, dex, con, intell, pow, cha)
+        // The previous test used (1,1,0,0,0,0) which might not align with a 6-param constructor if order matters or if 0 is invalid for some.
+        // However, CreateCharacterClassRequest itself doesn't directly take PlayerStatModel but individual stats.
+        // Let's use the actual fields from CreateCharacterClassRequest for clarity in createTestCharacterClass
+        CreateCharacterClassRequest correctedCreateRequest = CreateCharacterClassRequest.builder()
+                .name(name)
+                .code(code)
+                .description(description)
+                .baseHp(10) // Example valid value
+                .baseMp(10) // Example valid value
+                .baseStr(5) // Example valid value
+                .baseDex(5) // Example valid value
+                .baseCon(5) // Example valid value
+                .baseIntelligence(5) // Example valid value
+                .basePow(5) // Example valid value
+                .baseCha(5) // Example valid value
+                .build();
+        String requestJson = objectMapper.writeValueAsString(correctedCreateRequest);
+
+        MvcResult result = mockMvc.perform(post(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        return objectMapper.readValue(result.getResponse().getContentAsString(), CharacterClassResponse.class);
+    }
+
+    private CharacterClassResponse getCharacterClassById(Long id) throws Exception {
+        MvcResult result = mockMvc.perform(get(BASE_URL + "/" + id)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return objectMapper.readValue(result.getResponse().getContentAsString(), CharacterClassResponse.class);
+    }
+
+    private List<CharacterClassResponse> getAllCharacterClasses() throws Exception {
+        MvcResult result = mockMvc.perform(get(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return objectMapper.readValue(result.getResponse().getContentAsString(), new TypeReference<List<CharacterClassResponse>>() {});
+    }
+
+    private CharacterClassResponse updateCharacterClass(Long classId, UpdateCharacterClassRequest updateRequest) throws Exception {
+        String updateRequestJson = objectMapper.writeValueAsString(updateRequest);
+
+        MvcResult result = mockMvc.perform(put(BASE_URL + "/" + classId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(updateRequestJson))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return objectMapper.readValue(result.getResponse().getContentAsString(), CharacterClassResponse.class);
+    }
+
+    private void deleteCharacterClass(Long classId) throws Exception {
+        mockMvc.perform(delete(BASE_URL + "/" + classId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+    }
+
+    private void assertCharacterClassEquals(CharacterClassResponse characterClass, String expectedName, String expectedCode, String expectedDescription, PlayerStatModel expectedStatBonus) {
+        assertThat(characterClass).isNotNull();
+        assertThat(characterClass.getName()).isEqualTo(expectedName);
+        assertThat(characterClass.getCode()).isEqualTo(expectedCode);
+        assertThat(characterClass.getDescription()).isEqualTo(expectedDescription);
+        // Ensure statBonus in CharacterClassResponse matches the expected PlayerStatModel structure
+        // This assumes CharacterClassResponse.getStatBonus() returns a PlayerStatModel compatible object
+        assertThat(characterClass.getStatBonus().getStr()).isEqualTo(expectedStatBonus.getStr());
+        assertThat(characterClass.getStatBonus().getDex()).isEqualTo(expectedStatBonus.getDex());
+        assertThat(characterClass.getStatBonus().getCon()).isEqualTo(expectedStatBonus.getCon());
+        assertThat(characterClass.getStatBonus().getIntelligence()).isEqualTo(expectedStatBonus.getIntelligence());
+        assertThat(characterClass.getStatBonus().getPow()).isEqualTo(expectedStatBonus.getPow());
+        assertThat(characterClass.getStatBonus().getCha()).isEqualTo(expectedStatBonus.getCha());
+        // Skills assertion can be added if skills are part of the test data
+    }
+
+    private void assertCharacterClassInList(List<CharacterClassResponse> classes, CharacterClassResponse expectedClass) {
+        boolean found = classes.stream()
+                .anyMatch(cc -> {
+                    boolean idsMatch = cc.getId().equals(expectedClass.getId());
+                    boolean namesMatch = cc.getName().equals(expectedClass.getName());
+                    boolean codesMatch = cc.getCode().equals(expectedClass.getCode());
+                    boolean descriptionsMatch = cc.getDescription().equals(expectedClass.getDescription());
+                    boolean statsMatch = cc.getStatBonus().getStr() == expectedClass.getStatBonus().getStr() &&
+                                         cc.getStatBonus().getDex() == expectedClass.getStatBonus().getDex() &&
+                                         cc.getStatBonus().getCon() == expectedClass.getStatBonus().getCon() &&
+                                         cc.getStatBonus().getIntelligence() == expectedClass.getStatBonus().getIntelligence() &&
+                                         cc.getStatBonus().getPow() == expectedClass.getStatBonus().getPow() &&
+                                         cc.getStatBonus().getCha() == expectedClass.getStatBonus().getCha();
+                    return idsMatch && namesMatch && codesMatch && descriptionsMatch && statsMatch;
+                });
+        assertThat(found).isTrue().withFailMessage("CharacterClass with id %s and code %s not found in the list or properties do not match.", expectedClass.getId(), expectedClass.getCode());
+    }
+}

--- a/src/test/java/com/jefflife/mudmk2/gamedata/adapter/in/MonsterTypeControllerSystemTest.java
+++ b/src/test/java/com/jefflife/mudmk2/gamedata/adapter/in/MonsterTypeControllerSystemTest.java
@@ -1,0 +1,231 @@
+package com.jefflife.mudmk2.gamedata.adapter.in;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jefflife.mudmk2.gamedata.application.service.model.request.CreateMonsterTypeRequest;
+import com.jefflife.mudmk2.gamedata.application.service.model.request.UpdateMonsterTypeRequest;
+import com.jefflife.mudmk2.gamedata.application.service.model.response.MonsterTypeResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@WithMockUser(username = "test@example.com", roles = "USER")
+public class MonsterTypeControllerSystemTest {
+
+    private static final String BASE_URL = "/api/v1/monster-types";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void createMonsterType_shouldCreateMonsterTypeAndReturnCreatedResponse() throws Exception {
+        // Given
+        String monsterTypeName = "Test Monster";
+        CreateMonsterTypeRequest createRequest = new CreateMonsterTypeRequest(monsterTypeName, 100, 10, 5);
+        String requestJson = objectMapper.writeValueAsString(createRequest);
+
+        // When
+        MvcResult result = mockMvc.perform(post(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        // Then
+        String responseJson = result.getResponse().getContentAsString();
+        MonsterTypeResponse response = objectMapper.readValue(responseJson, MonsterTypeResponse.class);
+
+        assertThat(response.id()).isNotNull();
+        assertMonsterTypeEquals(response, monsterTypeName, 100, 10, 5);
+
+        // Verify Location header
+        String locationHeader = result.getResponse().getHeader("Location");
+        assertThat(locationHeader).isEqualTo(BASE_URL + "/" + response.id());
+    }
+
+    @Test
+    void getMonsterType_whenNotFound_shouldReturnNotFound() throws Exception {
+        // Given
+        long nonExistentId = -999L;
+
+        // When & Then
+        mockMvc.perform(get(BASE_URL + "/" + nonExistentId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void updateMonsterType_whenNotFound_shouldReturnNotFound() throws Exception {
+        // Given
+        long nonExistentId = -999L;
+        UpdateMonsterTypeRequest updateRequest = new UpdateMonsterTypeRequest("Non Existent", 1, 1, 1);
+        String requestJson = objectMapper.writeValueAsString(updateRequest);
+
+        // When & Then
+        mockMvc.perform(put(BASE_URL + "/" + nonExistentId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getMonsterTypes_shouldReturnAllMonsterTypes() throws Exception {
+        // Given
+        MonsterTypeResponse createdMonsterType1 = createTestMonsterType("Test Monster 1", 100, 10, 5);
+        MonsterTypeResponse createdMonsterType2 = createTestMonsterType("Test Monster 2", 120, 12, 6);
+
+        // When
+        List<MonsterTypeResponse> monsterTypes = getAllMonsterTypes();
+
+        // Then
+        assertThat(monsterTypes).isNotNull();
+        assertThat(monsterTypes.size()).isGreaterThanOrEqualTo(2);
+
+        // Verify that the created monster types are in the response
+        assertMonsterTypeInList(monsterTypes, createdMonsterType1);
+        assertMonsterTypeInList(monsterTypes, createdMonsterType2);
+    }
+
+    @Test
+    void getMonsterType_shouldReturnMonsterTypeById() throws Exception {
+        // Given
+        MonsterTypeResponse createdMonsterType = createTestMonsterType("Test Monster for GetById", 150, 15, 7);
+
+        // When
+        MonsterTypeResponse retrievedMonsterType = getMonsterTypeById(createdMonsterType.id());
+
+        // Then
+        assertThat(retrievedMonsterType.id()).isEqualTo(createdMonsterType.id());
+        assertMonsterTypeEquals(retrievedMonsterType, "Test Monster for GetById", 150, 15, 7);
+    }
+
+    @Test
+    void updateMonsterType_shouldUpdateMonsterTypeAndReturnUpdatedResponse() throws Exception {
+        // Given
+        MonsterTypeResponse createdMonsterType = createTestMonsterType("Original Monster Name", 200, 20, 10);
+
+        // When
+        String updatedMonsterTypeName = "Updated Monster Name";
+        UpdateMonsterTypeRequest updateRequest = new UpdateMonsterTypeRequest(updatedMonsterTypeName, 220, 22, 11);
+        MonsterTypeResponse updatedMonsterType = updateMonsterType(createdMonsterType.id(), updateRequest);
+
+        // Then
+        assertThat(updatedMonsterType.id()).isEqualTo(createdMonsterType.id());
+        assertMonsterTypeEquals(updatedMonsterType, updatedMonsterTypeName, 220, 22, 11);
+
+        // Verify that the monster type was actually updated in the database
+        MonsterTypeResponse retrievedMonsterType = getMonsterTypeById(createdMonsterType.id());
+        assertMonsterTypeEquals(retrievedMonsterType, updatedMonsterTypeName, 220, 22, 11);
+    }
+
+    @Test
+    void deleteMonsterType_shouldDeleteMonsterTypeAndReturnNoContent() throws Exception {
+        // Given
+        MonsterTypeResponse createdMonsterType = createTestMonsterType("Test Monster for Delete", 50, 5, 2);
+
+        // When
+        deleteMonsterType(createdMonsterType.id());
+
+        // Then
+        // Verify that the monster type was actually deleted from the database
+        mockMvc.perform(get(BASE_URL + "/" + createdMonsterType.id())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void deleteMonsterType_whenNotFound_shouldReturnNotFound() throws Exception {
+        // Given
+        long nonExistentId = -999L;
+
+        // When & Then
+        mockMvc.perform(delete(BASE_URL + "/" + nonExistentId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    private MonsterTypeResponse createTestMonsterType(String name, int maxHp, int attack, int defense) throws Exception {
+        CreateMonsterTypeRequest createRequest = new CreateMonsterTypeRequest(name, maxHp, attack, defense);
+        String requestJson = objectMapper.writeValueAsString(createRequest);
+
+        MvcResult result = mockMvc.perform(post(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        return objectMapper.readValue(result.getResponse().getContentAsString(), MonsterTypeResponse.class);
+    }
+
+    private MonsterTypeResponse getMonsterTypeById(Long id) throws Exception {
+        MvcResult result = mockMvc.perform(get(BASE_URL + "/" + id)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return objectMapper.readValue(result.getResponse().getContentAsString(), MonsterTypeResponse.class);
+    }
+
+    private List<MonsterTypeResponse> getAllMonsterTypes() throws Exception {
+        MvcResult result = mockMvc.perform(get(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return objectMapper.readValue(result.getResponse().getContentAsString(), new TypeReference<List<MonsterTypeResponse>>() {});
+    }
+
+    private MonsterTypeResponse updateMonsterType(Long monsterTypeId, UpdateMonsterTypeRequest updateRequest) throws Exception {
+        String updateRequestJson = objectMapper.writeValueAsString(updateRequest);
+
+        MvcResult result = mockMvc.perform(put(BASE_URL + "/" + monsterTypeId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(updateRequestJson))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return objectMapper.readValue(result.getResponse().getContentAsString(), MonsterTypeResponse.class);
+    }
+
+    private void deleteMonsterType(Long monsterTypeId) throws Exception {
+        mockMvc.perform(delete(BASE_URL + "/" + monsterTypeId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+    }
+
+    private void assertMonsterTypeEquals(MonsterTypeResponse monsterType, String expectedName, int expectedMaxHp, int expectedAttack, int expectedDefense) {
+        assertThat(monsterType).isNotNull();
+        assertThat(monsterType.name()).isEqualTo(expectedName);
+        assertThat(monsterType.maxHp()).isEqualTo(expectedMaxHp);
+        assertThat(monsterType.attack()).isEqualTo(expectedAttack);
+        assertThat(monsterType.defense()).isEqualTo(expectedDefense);
+    }
+
+    private void assertMonsterTypeInList(List<MonsterTypeResponse> monsterTypes, MonsterTypeResponse expectedMonsterType) {
+        boolean found = false;
+        for (MonsterTypeResponse monsterType : monsterTypes) {
+            if (monsterType.id().equals(expectedMonsterType.id())) {
+                found = true;
+                assertMonsterTypeEquals(monsterType, expectedMonsterType.name(), expectedMonsterType.maxHp(), expectedMonsterType.attack(), expectedMonsterType.defense());
+                break;
+            }
+        }
+        assertThat(found).isTrue().withFailMessage("MonsterType with id %s not found in the list.", expectedMonsterType.id());
+    }
+}


### PR DESCRIPTION
This commit introduces system tests for `MonsterTypeController` and `CharacterClassController`.

For `MonsterTypeController`, the tests cover:
- CRUD operations (Create, Read, Update, Delete).
- Verification of 404 Not Found responses for operations on non-existent resources.

For `CharacterClassController`, the tests cover:
- CRUD operations (Create, Read, Update, Delete).
- Retrieval by ID and by code.
- The `POST /api/character-classes/initialize` endpoint.
- Verification of 404 Not Found responses for operations on non-existent resources.
- Basic input validation for creation.

The tests are based on the structure of existing system tests in the project, utilizing `MockMvc` and `ObjectMapper`.